### PR TITLE
Remove sharp and jimp from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,9 +32,3 @@ updates:
       - dependency-name: "eslint"
         versions:
           - ">= 8.57.1"
-      - dependency-name: "sharp"
-        versions:
-          - ">= 0.32.6"
-      - dependency-name: "jimp"
-        versions:
-          - ">= 0.16.13"


### PR DESCRIPTION
The dependencies 'sharp' and 'jimp' have been removed from the list of monitored packages in .github/dependabot.yml. This streamlines dependency updates to only include relevant packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplificação da configuração do Dependabot, permitindo atualizações automáticas para mais dependências.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->