### PR TITLE
Fix translation path for production build

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   minify: true,
   format: ['cjs', 'esm'],
   onSuccess: async () => {
-    cpSync('src/utils/translations', 'dist/translations', { recursive: true });
+    cpSync('src/utils/translations', 'dist/utils/translations', { recursive: true });
   },
   loader: {
     '.json': 'file',


### PR DESCRIPTION
## Summary
- ensure pt-BR translations are copied into the location that runtime expects

## Testing
- `npm run lint:check`
- `npm run build` *(fails: Module '@prisma/client' has no exported member)*

------
https://chatgpt.com/codex/tasks/task_e_688976f20c048320ac5da3394f98e495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Atualizado o local de destino dos arquivos de tradução após o build para `dist/utils/translations`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->