### PR TITLE
Add safeAxios wrapper to mitigate Axios vulnerabilities

### DIFF
--- a/src/api/controllers/proxy.controller.ts
+++ b/src/api/controllers/proxy.controller.ts
@@ -5,7 +5,7 @@ import { ProxyService } from '@api/services/proxy.service';
 import { Logger } from '@config/logger.config';
 import { BadRequestException, NotFoundException } from '@exceptions';
 import { makeProxyAgent } from '@utils/makeProxyAgent';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 
 const logger = new Logger('ProxyController');
 
@@ -48,8 +48,9 @@ export class ProxyController {
 
   public async testProxy(proxy: ProxyDto) {
     try {
-      const serverIp = await axios.get('https://icanhazip.com/');
-      const response = await axios.get('https://icanhazip.com/', {
+      const client = createSafeAxios();
+      const serverIp = await client.get('https://icanhazip.com/');
+      const response = await client.get('https://icanhazip.com/', {
         httpsAgent: makeProxyAgent(proxy),
       });
 

--- a/src/api/integrations/channel/evolution/evolution.channel.service.ts
+++ b/src/api/integrations/channel/evolution/evolution.channel.service.ts
@@ -16,7 +16,7 @@ import { Events, wa } from '@api/types/wa.types';
 import { Chatwoot, ConfigService, Openai, S3 } from '@config/env.config';
 import { BadRequestException, InternalServerErrorException } from '@exceptions';
 import { createJid } from '@utils/createJid';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 import { isBase64, isURL } from 'class-validator';
 import EventEmitter2 from 'eventemitter2';
 import FormData from 'form-data';
@@ -640,7 +640,8 @@ export class EvolutionStartupService extends ChannelStartupService {
 
         formData.append('format', 'mp4');
 
-        const response = await axios.post(process.env.API_AUDIO_CONVERTER, formData, {
+        const client = createSafeAxios();
+        const response = await client.post(process.env.API_AUDIO_CONVERTER, formData, {
           headers: {
             ...formData.getHeaders(),
             apikey: process.env.API_AUDIO_CONVERTER_KEY,

--- a/src/api/integrations/channel/meta/meta.controller.ts
+++ b/src/api/integrations/channel/meta/meta.controller.ts
@@ -1,7 +1,7 @@
 import { PrismaRepository } from '@api/repository/repository.service';
 import { WAMonitoringService } from '@api/services/monitor.service';
 import { Logger } from '@config/logger.config';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 
 import { ChannelController, ChannelControllerInterface } from '../channel.controller';
 
@@ -28,7 +28,8 @@ export class MetaController extends ChannelController implements ChannelControll
 
         const { webhookUrl } = template;
 
-        await axios.post(webhookUrl, data.entry[0].changes[0].value, {
+        const client = createSafeAxios();
+        await client.post(webhookUrl, data.entry[0].changes[0].value, {
           headers: {
             'Content-Type': 'application/json',
           },

--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -24,7 +24,7 @@ import { Chatwoot, ConfigService, Database, Openai, S3, WaBusiness } from '@conf
 import { BadRequestException, InternalServerErrorException } from '@exceptions';
 import { createJid } from '@utils/createJid';
 import { status } from '@utils/renderStatus';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 import { arrayUnique, isURL } from 'class-validator';
 import EventEmitter2 from 'eventemitter2';
 import FormData from 'form-data';
@@ -80,7 +80,7 @@ export class BusinessStartupService extends ChannelStartupService {
       const version = this.configService.get<WaBusiness>('WA_BUSINESS').VERSION;
       urlServer = `${urlServer}/${version}/${this.number}/${params}`;
       const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${this.token}` };
-      const result = await axios.post(urlServer, message, { headers });
+      const result = await createSafeAxios().post(urlServer, message, { headers });
       return result.data;
     } catch (e) {
       return e.response?.data?.error;
@@ -148,10 +148,10 @@ export class BusinessStartupService extends ChannelStartupService {
       const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${this.token}` };
 
       // Primeiro, obtenha a URL do arquivo
-      let result = await axios.get(urlServer, { headers });
+      let result = await createSafeAxios().get(urlServer, { headers });
 
       // Depois, baixe o arquivo usando a URL retornada
-      result = await axios.get(result.data.url, {
+      result = await createSafeAxios().get(result.data.url, {
         headers: { Authorization: `Bearer ${this.token}` }, // Use apenas o token de autorização para download
         responseType: 'arraybuffer',
       });
@@ -440,9 +440,9 @@ export class BusinessStartupService extends ChannelStartupService {
                 const version = this.configService.get<WaBusiness>('WA_BUSINESS').VERSION;
                 urlServer = `${urlServer}/${version}/${id}`;
                 const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${this.token}` };
-                const result = await axios.get(urlServer, { headers });
+                const result = await createSafeAxios().get(urlServer, { headers });
 
-                const buffer = await axios.get(result.data.url, {
+                const buffer = await createSafeAxios().get(result.data.url, {
                   headers: { Authorization: `Bearer ${this.token}` }, // Use apenas o token de autorização para download
                   responseType: 'arraybuffer',
                 });
@@ -791,7 +791,7 @@ export class BusinessStartupService extends ChannelStartupService {
             });
 
             if (findMessage.webhookUrl) {
-              await axios.post(findMessage.webhookUrl, message);
+              await createSafeAxios().post(findMessage.webhookUrl, message);
             }
           }
         }
@@ -1177,7 +1177,7 @@ export class BusinessStartupService extends ChannelStartupService {
 
       if (isFile === false) {
         if (isURL(mediaMessage.media)) {
-          const response = await axios.get(mediaMessage.media, { responseType: 'arraybuffer' });
+          const response = await createSafeAxios().get(mediaMessage.media, { responseType: 'arraybuffer' });
           const buffer = Buffer.from(response.data, 'base64');
           formData.append('file', buffer, {
             filename: mediaMessage.fileName || 'media',
@@ -1209,7 +1209,7 @@ export class BusinessStartupService extends ChannelStartupService {
         this.configService.get<WaBusiness>('WA_BUSINESS').VERSION
       }/${this.number}/media`;
 
-      const res = await axios.post(url, formData, { headers });
+      const res = await createSafeAxios().post(url, formData, { headers });
       return res.data.id;
     } catch (error) {
       this.logger.error(error.response.data);
@@ -1308,7 +1308,7 @@ export class BusinessStartupService extends ChannelStartupService {
 
       formData.append('format', 'mp3');
 
-      const response = await axios.post(process.env.API_AUDIO_CONVERTER, formData, {
+      const response = await createSafeAxios().post(process.env.API_AUDIO_CONVERTER, formData, {
         headers: {
           ...formData.getHeaders(),
           apikey: process.env.API_AUDIO_CONVERTER_KEY,

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -84,10 +84,10 @@ import { fetchLatestWaWebVersion } from '@utils/fetchLatestWaWebVersion';
 import { makeProxyAgent } from '@utils/makeProxyAgent';
 import { getOnWhatsappCache, saveOnWhatsappCache } from '@utils/onWhatsappCache';
 import { status } from '@utils/renderStatus';
+import { createSafeAxios } from '@utils/safeAxios';
 import useMultiFileAuthStatePrisma from '@utils/use-multi-file-auth-state-prisma';
 import { AuthStateProvider } from '@utils/use-multi-file-auth-state-provider-files';
 import { useMultiFileAuthStateRedisDb } from '@utils/use-multi-file-auth-state-redis-db';
-import axios from 'axios';
 import makeWASocket, {
   AnyMessageContent,
   BufferedEventData,
@@ -573,7 +573,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
       if (this.localProxy?.host?.includes('proxyscrape')) {
         try {
-          const response = await axios.get(this.localProxy?.host);
+          const response = await createSafeAxios().get(this.localProxy?.host);
           const text = response.data;
           const proxyUrls = text.split('\r\n');
           const rand = Math.floor(Math.random() * Math.floor(proxyUrls.length));
@@ -2491,7 +2491,7 @@ export class BaileysStartupService extends ChannelStartupService {
             };
           }
 
-          const response = await axios.get(mediaMessage.media, config);
+          const response = await createSafeAxios().get(mediaMessage.media, config);
 
           mimetype = response.headers['content-type'];
         }
@@ -2578,7 +2578,7 @@ export class BaileysStartupService extends ChannelStartupService {
           };
         }
 
-        const response = await axios.get(url, config);
+        const response = await createSafeAxios().get(url, config);
         imageBuffer = Buffer.from(response.data, 'binary');
       }
 
@@ -2693,7 +2693,7 @@ export class BaileysStartupService extends ChannelStartupService {
     let inputStream: PassThrough;
 
     if (isURL(audio)) {
-      const response = await axios.get(audio, { responseType: 'stream' });
+      const response = await createSafeAxios().get(audio, { responseType: 'stream' });
       inputStream = response.data;
     } else {
       const audioBuffer = Buffer.from(audio, 'base64');
@@ -2767,7 +2767,7 @@ export class BaileysStartupService extends ChannelStartupService {
         formData.append('base64', audio);
       }
 
-      const { data } = await axios.post(process.env.API_AUDIO_CONVERTER, formData, {
+      const { data } = await createSafeAxios().post(process.env.API_AUDIO_CONVERTER, formData, {
         headers: { ...formData.getHeaders(), apikey: process.env.API_AUDIO_CONVERTER_KEY },
       });
 
@@ -2788,7 +2788,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
         const config: any = { responseType: 'stream' };
 
-        const response = await axios.get(url, config);
+        const response = await createSafeAxios().get(url, config);
         inputAudioStream = response.data.pipe(new PassThrough());
       } else {
         const audioBuffer = Buffer.from(audio, 'base64');
@@ -3729,7 +3729,7 @@ export class BaileysStartupService extends ChannelStartupService {
           };
         }
 
-        pic = (await axios.get(url, config)).data;
+        pic = (await createSafeAxios().get(url, config)).data;
       } else if (isBase64(picture)) {
         pic = Buffer.from(picture, 'base64');
       } else {
@@ -4013,7 +4013,7 @@ export class BaileysStartupService extends ChannelStartupService {
           };
         }
 
-        pic = (await axios.get(url, config)).data;
+        pic = (await createSafeAxios().get(url, config)).data;
       } else if (isBase64(picture.image)) {
         pic = Buffer.from(picture.image, 'base64');
       } else {

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -21,8 +21,8 @@ import ChatwootClient, {
 import { request as chatwootRequest } from '@figuro/chatwoot-sdk/dist/core/request';
 import { Chatwoot as ChatwootModel, Contact as ContactModel, Message as MessageModel } from '@prisma/client';
 import i18next from '@utils/i18n';
+import { createSafeAxios } from '@utils/safeAxios';
 import { sendTelemetry } from '@utils/sendTelemetry';
-import axios from 'axios';
 import { proto } from 'baileys';
 import dayjs from 'dayjs';
 import FormData from 'form-data';
@@ -1046,7 +1046,8 @@ export class ChatwootService {
     };
 
     try {
-      const { data } = await axios.request(config);
+      const client = createSafeAxios();
+      const { data } = await client.request(config);
 
       return data;
     } catch (error) {
@@ -1119,7 +1120,8 @@ export class ChatwootService {
     };
 
     try {
-      const { data } = await axios.request(config);
+      const client = createSafeAxios();
+      const { data } = await client.request(config);
 
       return data;
     } catch (error) {
@@ -1137,7 +1139,8 @@ export class ChatwootService {
         const parts = media.split('/');
         fileName = decodeURIComponent(parts[parts.length - 1]);
 
-        const response = await axios.get(media, {
+        const client = createSafeAxios();
+        const response = await client.get(media, {
           responseType: 'arraybuffer',
         });
         mimeType = response.headers['content-type'];
@@ -2131,7 +2134,8 @@ export class ChatwootService {
 
         const isAdsMessage = (adsMessage && adsMessage.title) || adsMessage.body || adsMessage.thumbnailUrl;
         if (isAdsMessage) {
-          const imgBuffer = await axios.get(adsMessage.thumbnailUrl, { responseType: 'arraybuffer' });
+          const client = createSafeAxios();
+          const imgBuffer = await client.get(adsMessage.thumbnailUrl, { responseType: 'arraybuffer' });
 
           const extension = mimeTypes.extension(imgBuffer.headers['content-type']);
           const mimeType = extension && mimeTypes.lookup(extension);

--- a/src/api/integrations/chatbot/dify/services/dify.service.ts
+++ b/src/api/integrations/chatbot/dify/services/dify.service.ts
@@ -3,7 +3,7 @@ import { WAMonitoringService } from '@api/services/monitor.service';
 import { Integration } from '@api/types/wa.types';
 import { ConfigService, HttpServer } from '@config/env.config';
 import { Dify, DifySetting, IntegrationSession } from '@prisma/client';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 
 import { BaseChatbotService } from '../../base-chatbot.service';
 import { OpenaiService } from '../../openai/services/openai.service';
@@ -94,7 +94,7 @@ export class DifyService extends BaseChatbotService<Dify, DifySetting> {
           await instance.client.sendPresenceUpdate('composing', remoteJid);
         }
 
-        const response = await axios.post(endpoint, payload, {
+        const response = await createSafeAxios().post(endpoint, payload, {
           headers: {
             Authorization: `Bearer ${dify.apiKey}`,
           },
@@ -156,7 +156,7 @@ export class DifyService extends BaseChatbotService<Dify, DifySetting> {
           await instance.client.sendPresenceUpdate('composing', remoteJid);
         }
 
-        const response = await axios.post(endpoint, payload, {
+        const response = await createSafeAxios().post(endpoint, payload, {
           headers: {
             Authorization: `Bearer ${dify.apiKey}`,
           },
@@ -218,7 +218,7 @@ export class DifyService extends BaseChatbotService<Dify, DifySetting> {
           await instance.client.sendPresenceUpdate('composing', remoteJid);
         }
 
-        const response = await axios.post(endpoint, payload, {
+        const response = await createSafeAxios().post(endpoint, payload, {
           headers: {
             Authorization: `Bearer ${dify.apiKey}`,
           },

--- a/src/api/integrations/chatbot/evoai/services/evoai.service.ts
+++ b/src/api/integrations/chatbot/evoai/services/evoai.service.ts
@@ -3,7 +3,7 @@ import { WAMonitoringService } from '@api/services/monitor.service';
 import { Integration } from '@api/types/wa.types';
 import { ConfigService, HttpServer } from '@config/env.config';
 import { Evoai, EvoaiSetting, IntegrationSession } from '@prisma/client';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 import { downloadMediaMessage } from 'baileys';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -147,7 +147,8 @@ export class EvoaiService extends BaseChatbotService<Evoai, EvoaiSetting> {
         await instance.client.sendPresenceUpdate('composing', remoteJid);
       }
 
-      const response = await axios.post(endpoint, payload, {
+      const client = createSafeAxios();
+      const response = await client.post(endpoint, payload, {
         headers: {
           'x-api-key': evoai.apiKey,
           'Content-Type': 'application/json',

--- a/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
+++ b/src/api/integrations/chatbot/evolutionBot/services/evolutionBot.service.ts
@@ -4,8 +4,8 @@ import { WAMonitoringService } from '@api/services/monitor.service';
 import { Integration } from '@api/types/wa.types';
 import { ConfigService, HttpServer } from '@config/env.config';
 import { EvolutionBot, EvolutionBotSetting, IntegrationSession } from '@prisma/client';
+import { createSafeAxios } from '@utils/safeAxios';
 import { sendTelemetry } from '@utils/sendTelemetry';
-import axios from 'axios';
 
 import { BaseChatbotService } from '../../base-chatbot.service';
 import { OpenaiService } from '../../openai/services/openai.service';
@@ -106,7 +106,8 @@ export class EvolutionBotService extends BaseChatbotService<EvolutionBot, Evolut
         };
       }
 
-      const response = await axios.post(endpoint, payload, {
+      const client = createSafeAxios();
+      const response = await client.post(endpoint, payload, {
         headers,
       });
 

--- a/src/api/integrations/chatbot/flowise/services/flowise.service.ts
+++ b/src/api/integrations/chatbot/flowise/services/flowise.service.ts
@@ -4,7 +4,7 @@ import { WAMonitoringService } from '@api/services/monitor.service';
 import { Integration } from '@api/types/wa.types';
 import { ConfigService, HttpServer } from '@config/env.config';
 import { Flowise as FlowiseModel, IntegrationSession } from '@prisma/client';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 
 import { BaseChatbotService } from '../../base-chatbot.service';
 import { OpenaiService } from '../../openai/services/openai.service';
@@ -116,7 +116,8 @@ export class FlowiseService extends BaseChatbotService<FlowiseModel> {
       return;
     }
 
-    const response = await axios.post(endpoint, payload, {
+    const client = createSafeAxios();
+    const response = await client.post(endpoint, payload, {
       headers,
     });
 

--- a/src/api/integrations/chatbot/n8n/services/n8n.service.ts
+++ b/src/api/integrations/chatbot/n8n/services/n8n.service.ts
@@ -2,7 +2,7 @@ import { PrismaRepository } from '@api/repository/repository.service';
 import { WAMonitoringService } from '@api/services/monitor.service';
 import { ConfigService, HttpServer } from '@config/env.config';
 import { IntegrationSession, N8n, N8nSetting } from '@prisma/client';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 
 import { BaseChatbotService } from '../../base-chatbot.service';
 import { OpenaiService } from '../../openai/services/openai.service';
@@ -73,7 +73,8 @@ export class N8nService extends BaseChatbotService<N8n, N8nSetting> {
         const auth = Buffer.from(`${n8n.basicAuthUser}:${n8n.basicAuthPass}`).toString('base64');
         headers['Authorization'] = `Basic ${auth}`;
       }
-      const response = await axios.post(endpoint, payload, { headers });
+      const client = createSafeAxios();
+      const response = await client.post(endpoint, payload, { headers });
       const message = response?.data?.output || response?.data?.answer;
 
       // Use base class method instead of custom implementation

--- a/src/api/integrations/chatbot/openai/services/openai.service.ts
+++ b/src/api/integrations/chatbot/openai/services/openai.service.ts
@@ -3,8 +3,8 @@ import { WAMonitoringService } from '@api/services/monitor.service';
 import { Integration } from '@api/types/wa.types';
 import { ConfigService, Language, Openai as OpenaiConfig } from '@config/env.config';
 import { IntegrationSession, OpenaiBot, OpenaiSetting } from '@prisma/client';
+import { createSafeAxios } from '@utils/safeAxios';
 import { sendTelemetry } from '@utils/sendTelemetry';
-import axios from 'axios';
 import { downloadMediaMessage } from 'baileys';
 import FormData from 'form-data';
 import OpenAI from 'openai';
@@ -590,7 +590,8 @@ export class OpenaiService extends BaseChatbotService<OpenaiBot, OpenaiSetting> 
               payloadData.remoteJid = remoteJid;
               payloadData.pushName = pushName;
 
-              const response = await axios.post(functionUrl, {
+              const client = createSafeAxios();
+              const response = await client.post(functionUrl, {
                 functionName: toolCall.function.name,
                 functionArguments: payloadData,
               });
@@ -662,7 +663,8 @@ export class OpenaiService extends BaseChatbotService<OpenaiBot, OpenaiSetting> 
     let audio: Buffer;
 
     if (msg.message.mediaUrl) {
-      audio = await axios.get(msg.message.mediaUrl, { responseType: 'arraybuffer' }).then((response) => {
+      const client = createSafeAxios();
+      audio = await client.get(msg.message.mediaUrl, { responseType: 'arraybuffer' }).then((response) => {
         return Buffer.from(response.data, 'binary');
       });
     } else if (msg.message.base64) {
@@ -691,7 +693,8 @@ export class OpenaiService extends BaseChatbotService<OpenaiBot, OpenaiSetting> 
 
     const apiKey = creds?.apiKey || this.configService.get<OpenaiConfig>('OPENAI').API_KEY_GLOBAL;
 
-    const response = await axios.post('https://api.openai.com/v1/audio/transcriptions', formData, {
+    const client = createSafeAxios();
+    const response = await client.post('https://api.openai.com/v1/audio/transcriptions', formData, {
       headers: {
         'Content-Type': 'multipart/form-data',
         Authorization: `Bearer ${apiKey}`,

--- a/src/api/integrations/chatbot/typebot/controllers/typebot.controller.ts
+++ b/src/api/integrations/chatbot/typebot/controllers/typebot.controller.ts
@@ -8,7 +8,7 @@ import { configService, Typebot } from '@config/env.config';
 import { Logger } from '@config/logger.config';
 import { BadRequestException } from '@exceptions';
 import { IntegrationSession, Typebot as TypebotModel } from '@prisma/client';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 
 import { BaseChatbotController } from '../../base-chatbot.controller';
 
@@ -270,7 +270,8 @@ export class TypebotController extends BaseChatbotController<TypebotModel, Typeb
             },
           };
         }
-        const request = await axios.post(url, reqData);
+        const client = createSafeAxios();
+        const request = await client.post(url, reqData);
 
         await this.typebotService.sendWAMessage(
           instanceData,

--- a/src/api/integrations/chatbot/typebot/services/typebot.service.ts
+++ b/src/api/integrations/chatbot/typebot/services/typebot.service.ts
@@ -3,8 +3,8 @@ import { WAMonitoringService } from '@api/services/monitor.service';
 import { Auth, ConfigService, HttpServer, Typebot } from '@config/env.config';
 import { Instance, IntegrationSession, Message, Typebot as TypebotModel } from '@prisma/client';
 import { getConversationMessage } from '@utils/getConversationMessage';
+import { createSafeAxios } from '@utils/safeAxios';
 import { sendTelemetry } from '@utils/sendTelemetry';
-import axios from 'axios';
 
 import { BaseChatbotService } from '../../base-chatbot.service';
 import { OpenaiService } from '../../openai/services/openai.service';
@@ -121,7 +121,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
           },
         };
       }
-      const request = await axios.post(url, reqData);
+      const request = await createSafeAxios().post(url, reqData);
 
       let session = null;
       if (request?.data?.sessionId) {
@@ -676,7 +676,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
               };
             }
 
-            const request = await axios.post(urlTypebot, reqData);
+            const request = await createSafeAxios().post(urlTypebot, reqData);
 
             await this.sendWAMessage(
               instance,
@@ -826,7 +826,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
               sessionId: data?.sessionId,
             };
           }
-          request = await axios.post(urlTypebot, reqData);
+          request = await createSafeAxios().post(urlTypebot, reqData);
 
           await this.sendWAMessage(
             instance,
@@ -931,7 +931,7 @@ export class TypebotService extends BaseChatbotService<TypebotModel, any> {
       }
     }
 
-    const request = await axios.post(urlTypebot, reqData);
+    const request = await createSafeAxios().post(urlTypebot, reqData);
 
     await this.sendWAMessage(
       instance,

--- a/src/api/integrations/event/webhook/webhook.controller.ts
+++ b/src/api/integrations/event/webhook/webhook.controller.ts
@@ -5,7 +5,8 @@ import { wa } from '@api/types/wa.types';
 import { configService, Log, Webhook } from '@config/env.config';
 import { Logger } from '@config/logger.config';
 import { BadRequestException } from '@exceptions';
-import axios, { AxiosInstance } from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
+import { AxiosInstance } from 'axios';
 import * as jwt from 'jsonwebtoken';
 
 import { EmitData, EventController, EventControllerInterface } from '../event.controller';
@@ -122,7 +123,7 @@ export class WebhookController extends EventController implements EventControlle
 
         try {
           if (instance?.enabled && regex.test(instance.url)) {
-            const httpService = axios.create({
+            const httpService = createSafeAxios({
               baseURL,
               headers: webhookHeaders as Record<string, string> | undefined,
               timeout: webhookConfig.REQUEST?.TIMEOUT_MS ?? 30000,
@@ -167,7 +168,7 @@ export class WebhookController extends EventController implements EventControlle
 
         try {
           if (regex.test(globalURL)) {
-            const httpService = axios.create({
+            const httpService = createSafeAxios({
               baseURL: globalURL,
               timeout: webhookConfig.REQUEST?.TIMEOUT_MS ?? 30000,
             });

--- a/src/api/provider/sessions.ts
+++ b/src/api/provider/sessions.ts
@@ -1,6 +1,6 @@
 import { Auth, ConfigService, ProviderSession } from '@config/env.config';
 import { Logger } from '@config/logger.config';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 import { execFileSync } from 'child_process';
 
 type ResponseSuccess = { status: number; data?: any };
@@ -27,12 +27,16 @@ export class ProviderFiles {
     if (this.config.ENABLED) {
       const url = `http://${this.config.HOST}:${this.config.PORT}`;
       try {
-        const response = await axios.options(url + '/ping');
+        const response = await createSafeAxios().options(url + '/ping');
         if (response?.data != 'pong') {
           throw new Error('Offline file provider.');
         }
 
-        await axios.post(`${url}/session`, { group: this.config.PREFIX }, { headers: { apikey: this.globalApiToken } });
+        await createSafeAxios().post(
+          `${url}/session`,
+          { group: this.config.PREFIX },
+          { headers: { apikey: this.globalApiToken } },
+        );
       } catch (error) {
         this.logger.error(['Failed to connect to the file server', error?.message, error?.stack]);
         const pid = process.pid;
@@ -47,7 +51,7 @@ export class ProviderFiles {
 
   public async create(instance: string): ResponseProvider {
     try {
-      const response = await axios.post(
+      const response = await createSafeAxios().post(
         `${this.baseUrl}`,
         {
           instance,
@@ -68,7 +72,7 @@ export class ProviderFiles {
 
   public async write(instance: string, key: string, data: any): ResponseProvider {
     try {
-      const response = await axios.post(`${this.baseUrl}/${instance}/${key}`, data, {
+      const response = await createSafeAxios().post(`${this.baseUrl}/${instance}/${key}`, data, {
         headers: { apikey: this.globalApiToken },
       });
       return [{ status: response.status, data: response?.data }];
@@ -85,7 +89,7 @@ export class ProviderFiles {
 
   public async read(instance: string, key: string): ResponseProvider {
     try {
-      const response = await axios.get(`${this.baseUrl}/${instance}/${key}`, {
+      const response = await createSafeAxios().get(`${this.baseUrl}/${instance}/${key}`, {
         headers: { apikey: this.globalApiToken },
       });
       return [{ status: response.status, data: response?.data }];
@@ -102,7 +106,7 @@ export class ProviderFiles {
 
   public async delete(instance: string, key: string): ResponseProvider {
     try {
-      const response = await axios.delete(`${this.baseUrl}/${instance}/${key}`, {
+      const response = await createSafeAxios().delete(`${this.baseUrl}/${instance}/${key}`, {
         headers: { apikey: this.globalApiToken },
       });
       return [{ status: response.status, data: response?.data }];
@@ -119,7 +123,9 @@ export class ProviderFiles {
 
   public async allInstances(): ResponseProvider {
     try {
-      const response = await axios.get(`${this.baseUrl}/list-instances`, { headers: { apikey: this.globalApiToken } });
+      const response = await createSafeAxios().get(`${this.baseUrl}/list-instances`, {
+        headers: { apikey: this.globalApiToken },
+      });
       return [{ status: response.status, data: response?.data as string[] }];
     } catch (error) {
       return [
@@ -134,7 +140,9 @@ export class ProviderFiles {
 
   public async removeSession(instance: string): ResponseProvider {
     try {
-      const response = await axios.delete(`${this.baseUrl}/${instance}`, { headers: { apikey: this.globalApiToken } });
+      const response = await createSafeAxios().delete(`${this.baseUrl}/${instance}`, {
+        headers: { apikey: this.globalApiToken },
+      });
       return [{ status: response.status, data: response?.data }];
     } catch (error) {
       return [

--- a/src/api/services/template.service.ts
+++ b/src/api/services/template.service.ts
@@ -3,7 +3,7 @@ import { TemplateDto } from '@api/dto/template.dto';
 import { PrismaRepository } from '@api/repository/repository.service';
 import { ConfigService, WaBusiness } from '@config/env.config';
 import { Logger } from '@config/logger.config';
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 
 import { WAMonitoringService } from './monitor.service';
 
@@ -87,10 +87,10 @@ export class TemplateService {
       urlServer = `${urlServer}/${version}/${this.businessId}/message_templates`;
       const headers = { 'Content-Type': 'application/json', Authorization: `Bearer ${this.token}` };
       if (method === 'GET') {
-        const result = await axios.get(urlServer, { headers });
+        const result = await createSafeAxios().get(urlServer, { headers });
         return result.data;
       } else if (method === 'POST') {
-        const result = await axios.post(urlServer, data, { headers });
+        const result = await createSafeAxios().post(urlServer, data, { headers });
         return result.data;
       }
     } catch (e) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,8 +11,8 @@ import { onUnexpectedError } from '@config/error.config';
 import { Logger } from '@config/logger.config';
 import { ROOT_DIR } from '@config/path.config';
 import * as Sentry from '@sentry/node';
+import { createSafeAxios } from '@utils/safeAxios';
 import { ServerUP } from '@utils/server-up';
-import axios from 'axios';
 import compression from 'compression';
 import cors from 'cors';
 import express, { json, NextFunction, Request, Response, urlencoded } from 'express';
@@ -94,7 +94,7 @@ async function bootstrap() {
           logger.error(errorData);
 
           const baseURL = webhook.EVENTS.ERRORS_WEBHOOK;
-          const httpService = axios.create({ baseURL });
+          const httpService = createSafeAxios({ baseURL });
 
           httpService.post('', errorData);
         }

--- a/src/utils/fetchLatestWaWebVersion.ts
+++ b/src/utils/fetchLatestWaWebVersion.ts
@@ -1,9 +1,11 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
+import { AxiosRequestConfig } from 'axios';
 import { fetchLatestBaileysVersion, WAVersion } from 'baileys';
 
 export const fetchLatestWaWebVersion = async (options: AxiosRequestConfig<{}>) => {
   try {
-    const { data } = await axios.get('https://web.whatsapp.com/sw.js', {
+    const client = createSafeAxios();
+    const { data } = await client.get('https://web.whatsapp.com/sw.js', {
       ...options,
       responseType: 'json',
     });

--- a/src/utils/safeAxios.ts
+++ b/src/utils/safeAxios.ts
@@ -1,0 +1,31 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+/**
+ * Create an Axios instance with security protections.
+ * - Disables automatic XSRF header injection.
+ * - Ensures requests stay within the configured baseURL.
+ */
+export function createSafeAxios(config: AxiosRequestConfig = {}): AxiosInstance {
+  const instance = axios.create({
+    xsrfCookieName: undefined,
+    xsrfHeaderName: undefined,
+    ...config,
+  });
+
+  instance.interceptors.request.use((cfg) => {
+    if (cfg.baseURL && cfg.url) {
+      try {
+        const resolved = new URL(cfg.url, cfg.baseURL);
+        if (!resolved.href.startsWith(cfg.baseURL)) {
+          throw new Error('Request URL outside of baseURL');
+        }
+        cfg.url = resolved.pathname + resolved.search + resolved.hash;
+      } catch (err) {
+        return Promise.reject(err);
+      }
+    }
+    return cfg;
+  });
+
+  return instance;
+}

--- a/src/utils/sendTelemetry.ts
+++ b/src/utils/sendTelemetry.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import { createSafeAxios } from '@utils/safeAxios';
 import fs from 'fs';
 
 const packageJson = JSON.parse(fs.readFileSync('./package.json', 'utf8'));
@@ -31,7 +31,8 @@ export const sendTelemetry = async (route: string): Promise<void> => {
       ? process.env.TELEMETRY_URL
       : 'https://log.pablofreitasnutri.com.br/telemetry';
 
-  axios
+  const client = createSafeAxios();
+  client
     .post(url, telemetry)
     .then(() => {})
     .catch(() => {});


### PR DESCRIPTION
## Summary
- create `createSafeAxios` wrapper disabling XSRF header and validating baseURL
- use `createSafeAxios` across API services and controllers
- remove unused Axios imports

## Testing
- `npm run lint`
- `npm run lint:check`
- `npm run build` *(fails: Module '"@prisma/client"' has no exported member 'Contact')*

------
https://chatgpt.com/codex/tasks/task_e_688979227f108320b9fcaa6bca9e4805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refatoração**
  * Todas as requisições HTTP passaram a utilizar um novo cliente personalizado para maior segurança, substituindo o uso direto do axios em diversos módulos do sistema.
  * Implementada uma função utilitária para criar instâncias seguras do cliente HTTP, com validações adicionais de URL e desativação automática de cabeçalhos XSRF.

* **Novos Recursos**
  * Adicionada a função utilitária para criação de clientes HTTP seguros.

* **Correção de Estilo**
  * Padronização do uso do cliente HTTP em todo o projeto.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->