### PR TITLE
Remove helmet and x-powered-by from Express setup

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,6 @@ import axios from 'axios';
 import compression from 'compression';
 import cors from 'cors';
 import express, { json, NextFunction, Request, Response, urlencoded } from 'express';
-import helmet from 'helmet';
 import { join } from 'path';
 
 function initWA() {
@@ -26,8 +25,6 @@ function initWA() {
 async function bootstrap() {
   const logger = new Logger('SERVER');
   const app = express();
-  app.use(helmet());
-  app.disable('x-powered-by');
 
   let providerFiles: ProviderFiles = null;
   if (configService.get<ProviderSession>('PROVIDER').ENABLED) {


### PR DESCRIPTION
The usage of helmet middleware and disabling of 'x-powered-by' header have been removed from the Express app initialization. This may be to simplify middleware usage or to address compatibility or configuration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refatoração**
  * Removido o uso do middleware de segurança para headers HTTP e a configuração relacionada ao cabeçalho `x-powered-by`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->