### PR TITLE
Disable 'x-powered-by' header in Express app

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ function initWA() {
 async function bootstrap() {
   const logger = new Logger('SERVER');
   const app = express();
+  app.disable('x-powered-by');
 
   let providerFiles: ProviderFiles = null;
   if (configService.get<ProviderSession>('PROVIDER').ENABLED) {


### PR DESCRIPTION
Added app.disable('x-powered-by') to enhance security by removing the Express signature from response headers.