### PR TITLE
Make allowed websocket hosts configurable via env

### DIFF
--- a/src/api/integrations/event/websocket/websocket.controller.ts
+++ b/src/api/integrations/event/websocket/websocket.controller.ts
@@ -31,11 +31,12 @@ export class WebsocketController extends EventController implements EventControl
           const params = new URLSearchParams(url.search);
 
           const { remoteAddress } = req.socket;
-          const isLocalhost =
-            remoteAddress === '127.0.0.1' || remoteAddress === '::1' || remoteAddress === '::ffff:127.0.0.1';
+          const isAllowedHost = (process.env.WEBSOCKET_ALLOWED_HOSTS || '127.0.0.1,::1,::ffff:127.0.0.1')
+            .split(',')
+            .map((h) => h.trim())
+            .includes(remoteAddress);
 
-          // Permite conexões internas do Socket.IO (EIO=4 é o Engine.IO v4)
-          if (params.has('EIO') && isLocalhost) {
+          if (params.has('EIO') && isAllowedHost) {
             return callback(null, true);
           }
 


### PR DESCRIPTION
Replaces hardcoded localhost checks with a WEBSOCKET_ALLOWED_HOSTS environment variable, allowing dynamic configuration of permitted remote addresses for websocket connections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Permite configurar os hosts autorizados para conexões WebSocket via variável de ambiente WEBSOCKET_ALLOWED_HOSTS.
  - Mantém comportamento padrão quando não configurada (endereços locais comuns).
  - Melhora o controle de acesso em ambientes de desenvolvimento, staging e produção sem alterar o fluxo de autenticação existente.
  - Facilita a habilitação de conexões a partir de hosts específicos conforme a necessidade operacional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->