### PR TITLE
Set response type to text/plain for webhook validation

### DIFF
--- a/src/api/integrations/channel/meta/meta.router.ts
+++ b/src/api/integrations/channel/meta/meta.router.ts
@@ -9,7 +9,7 @@ export class MetaRouter extends RouterBroker {
     this.router
       .get(this.routerPath('webhook/meta', false), async (req, res) => {
         const token = req.query['hub.verify_token'];
-        if (token === configService.get<WaBusiness>('WA_BUSINESS').TOKEN_WEBHOOK) {
+        if (token === this.configService.get<WaBusiness>('WA_BUSINESS').TOKEN_WEBHOOK) {
           res.type('text/plain').send(String(req.query['hub.challenge'] || ''));
         } else {
           res.type('text/plain').send('Error, wrong validation token');


### PR DESCRIPTION
Updated the webhook validation endpoint to explicitly set the response Content-Type to 'text/plain' for both success and error cases. This ensures proper response formatting for webhook verification requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Correções de Bugs**
  * Validação do webhook (GET) mais rigorosa, extraindo e comparando o token contra a configuração esperada para evitar autorizações indevidas.
  * Respostas padronizadas com content-type text/plain em sucesso e erro para maior previsibilidade nas integrações.
  * Retorno do challenge garantindo valor em string (com default vazio) e mensagens de erro mais claras quando a validação falha.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->