### PR TITLE
Fix mediaKey assignment for WhatsApp media messages

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3601,7 +3601,7 @@ export class BaileysStartupService extends ChannelStartupService {
       }
 
       if (typeof mediaMessage['mediaKey'] === 'object') {
-        msg.message = JSON.parse(JSON.stringify(msg.message));
+        msg.message[mediaType].mediaKey = Uint8Array.from(Object.values(mediaMessage['mediaKey']));
       }
 
       let buffer: Buffer;


### PR DESCRIPTION
Replaces deep cloning of message with direct conversion of mediaKey object to Uint8Array for the specified mediaType. This ensures proper handling of mediaKey when it is an object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Correções de bugs**
  - Maior confiabilidade no envio e recebimento de mídias (imagens, áudios, documentos) na integração com WhatsApp.
  - Reduz erros ao processar anexos e melhora a compatibilidade com diferentes formatos de mensagem.
  - Evita travamentos ocasionais ao lidar com arquivos de mídia.

- **Performance**
  - Processamento de mídias mais eficiente na integração com WhatsApp.
  - Menor consumo de memória e tempos de processamento reduzidos ao manipular anexos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->