### PR TITLE
Remove schema prefix from Kafka table migration

### DIFF
--- a/prisma/postgresql-migrations/20250918182355_add_kafka_integration/migration.sql
+++ b/prisma/postgresql-migrations/20250918182355_add_kafka_integration/migration.sql
@@ -1,5 +1,5 @@
 -- CreateTable
-CREATE TABLE "public"."Kafka" (
+CREATE TABLE "Kafka" (
     "id" TEXT NOT NULL,
     "enabled" BOOLEAN NOT NULL DEFAULT false,
     "events" JSONB NOT NULL,
@@ -11,7 +11,7 @@ CREATE TABLE "public"."Kafka" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "Kafka_instanceId_key" ON "public"."Kafka"("instanceId");
+CREATE UNIQUE INDEX "Kafka_instanceId_key" ON "Kafka"("instanceId");
 
 -- AddForeignKey
-ALTER TABLE "public"."Kafka" ADD CONSTRAINT "Kafka_instanceId_fkey" FOREIGN KEY ("instanceId") REFERENCES "public"."Instance"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Kafka" ADD CONSTRAINT "Kafka_instanceId_fkey" FOREIGN KEY ("instanceId") REFERENCES "Instance"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Padroniza objetos do banco ao remover qualificações de esquema, alinhando referências internas e melhorando consistência entre tabelas.
- Chores
  - Atualiza migração de banco para refletir a padronização e reduzir acoplamento a esquemas específicos, facilitando manutenção futura.
- Impacto para o usuário
  - Nenhuma mudança visível; o comportamento do aplicativo permanece inalterado.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->