### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
     "socks-proxy-agent": "^8.0.5",
     "swagger-ui-express": "^5.0.1",
     "tsup": "^8.3.5",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "express-rate-limit": "^8.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.0.0",


### PR DESCRIPTION
Potential fix for [https://github.com/pablopfg/evolution-api/security/code-scanning/13](https://github.com/pablopfg/evolution-api/security/code-scanning/13)

To fix the detected "Missing rate limiting" error, a rate-limiting middleware such as `express-rate-limit` should be applied to the `/assets/*` route handler. This will restrict the number of requests clients can make to this endpoint over a given time window, thus mitigating the risk of DoS attacks that exploit repeated file system access.

- In `src/api/routes/index.router.ts`, add an import for `express-rate-limit`.
- Configure a reasonably strict rate limit for the `/assets/*` endpoint, e.g., 100 requests per 15 minutes per IP (adjustable depending on expected traffic).
- Apply this rate limiter middleware specifically to the `/assets/*` route.
- No other code paths need to be changed, and this middleware will not disrupt legitimate users but will guard against abuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
