### PR TITLE
Potential fix for code scanning alert no. 16: Reflected cross-site scripting

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
     "socks-proxy-agent": "^8.0.5",
     "swagger-ui-express": "^5.0.1",
     "tsup": "^8.3.5",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.0.0",

--- a/src/api/integrations/channel/meta/meta.router.ts
+++ b/src/api/integrations/channel/meta/meta.router.ts
@@ -2,6 +2,7 @@ import { RouterBroker } from '@api/abstract/abstract.router';
 import { metaController } from '@api/server.module';
 import { ConfigService, WaBusiness } from '@config/env.config';
 import { Router } from 'express';
+import escape from 'escape-html';
 
 export class MetaRouter extends RouterBroker {
   constructor(readonly configService: ConfigService) {
@@ -10,7 +11,7 @@ export class MetaRouter extends RouterBroker {
       .get(this.routerPath('webhook/meta', false), async (req, res) => {
         const token = req.query['hub.verify_token'];
         if (token === this.configService.get<WaBusiness>('WA_BUSINESS').TOKEN_WEBHOOK) {
-          res.type('text/plain').send(String(req.query['hub.challenge'] || ''));
+          res.type('text/plain').send(escape(String(req.query['hub.challenge'] || '')));
         } else {
           res.type('text/plain').send('Error, wrong validation token');
         }


### PR DESCRIPTION
Potential fix for [https://github.com/pablopfg/evolution-api/security/code-scanning/16](https://github.com/pablopfg/evolution-api/security/code-scanning/16)

To fix the reflected XSS vulnerability, the value extracted from `req.query['hub.challenge']` must be safely output-encoded before including it in the response, even though the response is sent as `text/plain`. This practice guards against situations where intermediate proxies, misconfigurations, or client bugs might mishandle content types or interpret output as something other than plain text. The best approach is to use an established library for escaping output, such as `escape-html`, to encode any potentially dangerous characters.  

Specifically:
- Import the `escape-html` package at the top of the file.
- Update line 13 so that instead of outputting `String(req.query['hub.challenge'] || '')` directly, output `escape(String(req.query['hub.challenge'] || ''))`.
- There is no need to modify any other logic, and no changes to the expected behavior should occur, as this endpoint is only meant to echo the challenge value per the webhook verification spec.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
