### PR TITLE
Simplify translations path resolution in i18n util

### DIFF
--- a/src/utils/i18n.ts
+++ b/src/utils/i18n.ts
@@ -3,37 +3,23 @@ import fs from 'fs';
 import i18next from 'i18next';
 import path from 'path';
 
-const distPath = path.resolve(process.cwd(), 'dist', 'translations');
-const srcPath = path.resolve(process.cwd(), 'src', 'utils', 'translations');
-
-let translationsPath;
-
-if (fs.existsSync(distPath)) {
-  translationsPath = distPath;
-} else if (fs.existsSync(srcPath)) {
-  translationsPath = srcPath;
-} else {
-  console.error('Translations directory not found in dist or src.');
-  // Fallback to a non-existent path or handle error appropriately
-  translationsPath = '';
-}
+const __dirname = path.resolve(process.cwd(), 'src', 'utils');
 
 const languages = ['en', 'pt-BR', 'es'];
+const translationsPath = path.join(__dirname, 'translations');
 const configService: ConfigService = new ConfigService();
 
 const resources: any = {};
 
-if (translationsPath) {
-  languages.forEach((language) => {
-    const languagePath = path.join(translationsPath, `${language}.json`);
-    if (fs.existsSync(languagePath)) {
-      const translationContent = fs.readFileSync(languagePath, 'utf8');
-      resources[language] = {
-        translation: JSON.parse(translationContent),
-      };
-    }
-  });
-}
+languages.forEach((language) => {
+  const languagePath = path.join(translationsPath, `${language}.json`);
+  if (fs.existsSync(languagePath)) {
+    const translationContent = fs.readFileSync(languagePath, 'utf8');
+    resources[language] = {
+      translation: JSON.parse(translationContent),
+    };
+  }
+});
 
 i18next.init({
   resources,


### PR DESCRIPTION
Refactored the logic for determining the translations directory by removing conditional checks for 'dist' and 'src' paths. Now, translations are always loaded from 'src/utils/translations', streamlining resource loading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Correções de bugs
  - Carregamento de traduções agora usa um caminho fixo, reduzindo inconsistências entre ambientes. Arquivos de idioma ausentes são ignorados sem afetar a experiência. Menos ruído de erros relacionados a traduções.
- Refatoração
  - Lógica de população de recursos de idioma simplificada para tornar o carregamento mais previsível e estável, sem alterações no funcionamento geral do aplicativo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->